### PR TITLE
no need to pass fake ids into confluence

### DIFF
--- a/src/adf_converter.rb
+++ b/src/adf_converter.rb
@@ -254,12 +254,10 @@ class AdfConverter < Asciidoctor::Converter::Base
         "parameters" => {
           "macroParams" => {},
           "macroMetadata" => {
-            "macroId" => { "value" => SecureRandom.uuid },
             "schemaVersion" => { "value" => "1" },
             "title" => "Table of Contents"
           }
-        },
-        "localId" => SecureRandom.uuid
+        }
       }
     }
   end
@@ -279,16 +277,13 @@ class AdfConverter < Asciidoctor::Converter::Base
         "parameters" => {
           "macroParams" => {
             "" => { "value" => node.id },
-            "legacyAnchorId" => { "value" => "LEGACY-#{node.id}" },
-            "_parentId" => { "value" => SecureRandom.uuid }
+            "legacyAnchorId" => { "value" => "LEGACY-#{node.id}" }
           },
           "macroMetadata" => {
-            "macroId" => { "value" => SecureRandom.uuid },
             "schemaVersion" => { "value" => "1" },
             "title" => "Anchor"
           }
-        },
-        "localId" => SecureRandom.uuid
+        }
       }
     }
   end

--- a/test/adf_converter_table_test.rb
+++ b/test/adf_converter_table_test.rb
@@ -322,7 +322,6 @@ class AdfConverterTableTest < Minitest::Test
     assert_kind_of AdfConverter, doc.converter
     result = JSON.parse(doc.converter.convert(doc, 'document'))
 
-    result_json = normalize_uuids(result)
     expected = {
       "version" => 1,
       "type" => "doc",
@@ -398,7 +397,7 @@ class AdfConverterTableTest < Minitest::Test
         }
       ]
     }
-    assert_equal expected, result_json
+    assert_equal expected, result
   end
 
   def test_convert_table_in_root_section
@@ -417,7 +416,7 @@ class AdfConverterTableTest < Minitest::Test
     assert_kind_of AdfConverter, doc.converter
     result = JSON.parse(doc.converter.convert(doc, 'document'))
 
-    result_json = normalize_uuids(result)
+    result_json = result
     expected = {
       "version" => 1,
       "type" => "doc",
@@ -499,38 +498,18 @@ class AdfConverterTableTest < Minitest::Test
                   "macroParams" => {
                     "" => { "value" => "_another_section_title" },
                     "legacyAnchorId" => { "value" => "LEGACY-_another_section_title" },
-                    "_parentId" => { "value" => "normalized-uuid" }
                   },
                   "macroMetadata" => {
-                    "macroId" => { "value" => "normalized-uuid" },
                     "schemaVersion" => { "value" => "1" },
                     "title" => "Anchor"
                   }
-                },
-                "localId" => "normalized-uuid"
+                }
               }
             }
           ]
         }
       ]
     }
-    assert_equal expected, result_json
-  end
-
-  private
-
-  def normalize_uuids(json)
-    case json
-    when Hash
-      json.each do |key, value|
-        json[key] = normalize_uuids(value)
-      end
-    when Array
-      json.map! { |item| normalize_uuids(item) }
-    when String
-      json.match?(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/) ? 'normalized-uuid' : json
-    else
-      json
-    end
+    assert_equal expected, result
   end
 end

--- a/test/adf_converter_test.rb
+++ b/test/adf_converter_test.rb
@@ -59,8 +59,6 @@ class AdfConverterTest < Minitest::Test
     assert_kind_of AdfConverter, doc.converter
     result = JSON.parse(doc.converter.convert(doc, 'document'))
 
-    result_json = normalize_uuids(result)
-
     expected = {
       "version" => 1,
       "type" => "doc",
@@ -82,15 +80,12 @@ class AdfConverterTest < Minitest::Test
                   "macroParams" => {
                     "" => { "value" => "_section_title" },
                     "legacyAnchorId" => { "value" => "LEGACY-_section_title" },
-                    "_parentId" => { "value" => "normalized-uuid" }
                   },
                   "macroMetadata" => {
-                    "macroId" => { "value" => "normalized-uuid" },
                     "schemaVersion" => { "value" => "1" },
                     "title" => "Anchor"
                   }
-                },
-                "localId" => "normalized-uuid"
+                }
               }
             }
           ]
@@ -107,7 +102,7 @@ class AdfConverterTest < Minitest::Test
       ]
     }
 
-    assert_equal expected, result_json
+    assert_equal expected, result
   end
 
   def test_convert_ulist
@@ -266,9 +261,6 @@ class AdfConverterTest < Minitest::Test
     assert_kind_of AdfConverter, doc.converter
     result = JSON.parse(doc.converter.convert(doc, 'document'))
 
-    # Normalize UUIDs in the result
-    result_json = normalize_uuids(result)
-
     expected = {
       "version" => 1,
       "type" => "doc",
@@ -290,15 +282,12 @@ class AdfConverterTest < Minitest::Test
                   "macroParams" => {
                     "" => { "value" => "section-anchor" },
                     "legacyAnchorId" => { "value" => "LEGACY-section-anchor" },
-                    "_parentId" => { "value" => "normalized-uuid" }
                   },
                   "macroMetadata" => {
-                    "macroId" => { "value" => "normalized-uuid" },
                     "schemaVersion" => { "value" => "1" },
                     "title" => "Anchor"
                   }
-                },
-                "localId" => "normalized-uuid"
+                }
               }
             }
           ]
@@ -329,9 +318,7 @@ class AdfConverterTest < Minitest::Test
       ]
     }
 
-    expected_json = normalize_uuids(expected)
-
-    assert_equal expected_json, result_json
+    assert_equal expected, result
   end
 
   def test_convert_toc_macro
@@ -347,9 +334,6 @@ class AdfConverterTest < Minitest::Test
     assert_kind_of AdfConverter, doc.converter
     result = JSON.parse(doc.converter.convert(doc, 'document'))
 
-    # Normalize UUIDs in the result
-    result_json = normalize_uuids(result)
-
     expected = {
       "version" => 1,
       "type" => "doc",
@@ -362,12 +346,10 @@ class AdfConverterTest < Minitest::Test
             "parameters" => {
               "macroParams" => {},
               "macroMetadata" => {
-                "macroId" => { "value" => "normalized-uuid" },
                 "schemaVersion" => { "value" => "1" },
                 "title" => "Table of Contents"
               }
-            },
-            "localId" => "normalized-uuid"
+            }
           }
         },
         {
@@ -384,15 +366,12 @@ class AdfConverterTest < Minitest::Test
                   "macroParams" => {
                     "" => { "value" => "_section_1" },
                     "legacyAnchorId" => { "value" => "LEGACY-_section_1" },
-                    "_parentId" => { "value" => "normalized-uuid" }
                   },
                   "macroMetadata" => {
-                    "macroId" => { "value" => "normalized-uuid" },
                     "schemaVersion" => { "value" => "1" },
                     "title" => "Anchor"
                   }
-                },
-                "localId" => "normalized-uuid"
+                }
               }
             }
           ]
@@ -411,15 +390,12 @@ class AdfConverterTest < Minitest::Test
                   "macroParams" => {
                     "" => { "value" => "_section_2" },
                     "legacyAnchorId" => { "value" => "LEGACY-_section_2" },
-                    "_parentId" => { "value" => "normalized-uuid" }
                   },
                   "macroMetadata" => {
-                    "macroId" => { "value" => "normalized-uuid" },
                     "schemaVersion" => { "value" => "1" },
                     "title" => "Anchor"
                   }
-                },
-                "localId" => "normalized-uuid"
+                }
               }
             }
           ]
@@ -427,7 +403,7 @@ class AdfConverterTest < Minitest::Test
       ]
     }
 
-    assert_equal expected, result_json
+    assert_equal expected, result
   end
 
   def test_convert_literal_blocks_with_languages


### PR DESCRIPTION
It seems like the Confluence API will set all IDs for the macro stubs itself. No need to pass IDs in