### PR TITLE
support page update in confluence upload script

### DIFF
--- a/helper_scripts/README.md
+++ b/helper_scripts/README.md
@@ -14,10 +14,27 @@ Install requirements (recommended: use [uv](https://github.com/astral-sh/uv)):
 uv pip install -r requirements.txt
 ```
 
-If you want to run from within the `helper_scripts` directory:
+### Creating or Updating a Page
+
+You can use the upload script to **create a new Confluence page** or **update an existing one**.  
+If you provide the `--page-id` option, the script will update the specified page (including attachments and content).  
+If you omit `--page-id`, a new page will be created.
+
+**Example: Create a new page**
 ```
 uv run upload_to_confluence.py --base-url https://your-domain.atlassian.net --asciidoc path/to/main.adoc --adf path/to/adf.json --space-id 123456 --title "Page Title" --username "user@example.com" --api-token "your-api-token"
 ```
+
+**Example: Update an existing page**
+```
+uv run upload_to_confluence.py --base-url https://your-domain.atlassian.net --asciidoc path/to/main.adoc --adf path/to/adf.json --space-id 123456 --title "Page Title" --username "user@example.com" --api-token "your-api-token" --page-id 987654
+```
+
+When updating, the script will:
+- Upload any new or changed images (using checksums to avoid unnecessary uploads)
+- Remove old attachments if they are replaced
+- Patch the ADF file with the correct attachment IDs
+- Update the page content in Confluence, incrementing the version as required
 
 ## Running Tests
 

--- a/helper_scripts/confluence_api.py
+++ b/helper_scripts/confluence_api.py
@@ -2,6 +2,7 @@ import os
 import json
 import requests
 import mimetypes
+import hashlib
 from urllib.parse import urljoin
 
 
@@ -60,7 +61,7 @@ def update_page_content(base_url, page_id, adf_json, username, api_token):
         "id": page_id,
         "status": status,
         "title": title,
-        "version": {"number": current_version},
+        "version": {"number": current_version + 1},  # increment version!
         "body": {"value": inner_json_str, "representation": "atlas_doc_format"},
     }
     url = urljoin(base_url, f"/wiki/api/v2/pages/{page_id}")
@@ -77,40 +78,152 @@ def update_page_content(base_url, page_id, adf_json, username, api_token):
         )
 
 
-def upload_images_to_confluence(base_url, images, page_id, username, api_token):
-    """Upload images to Confluence."""
+def get_page_attachments(base_url, page_id, username, api_token):
+    """Get all attachments for a page."""
+    url = urljoin(
+        base_url, f"/wiki/rest/api/content/{page_id}/child/attachment?expand=extensions"
+    )
+    headers = {"Authorization": requests.auth._basic_auth_str(username, api_token)}
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        return response.json().get("results", [])
+    else:
+        print(f"Failed to fetch attachments: {response.status_code} - {response.text}")
+        return []
+
+
+def _get_attachment_download_url(base_url, attachment):
+    download_path = attachment.get("_links", {}).get("download")
+    if not download_path:
+        return None
+
+    if not download_path.startswith("/wiki"):
+        download_path = "/wiki" + download_path if not download_path.startswith("/") else "/wiki" + download_path
+    return urljoin(base_url, download_path)
+
+
+def _calculate_file_sha256(filepath):
+    sha256 = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def _calculate_remote_sha256(url, username, api_token):
+    sha256 = hashlib.sha256()
+    headers = {"Authorization": requests.auth._basic_auth_str(username, api_token)}
+    response = requests.get(url, headers=headers, stream=True)
+
+    if response.status_code == 200:
+        for chunk in response.iter_content(8192):
+            sha256.update(chunk)
+        return sha256.hexdigest()
+    else:
+        print(
+            f"Failed to download attachment for checksum: {response.status_code} - {response.text}"
+        )
+        return None
+
+def delete_attachment(base_url, attachment_id, username, api_token):
+    """Delete an attachment by its ID."""
+    delete_url = urljoin(base_url, f"/wiki/rest/api/content/{attachment_id}")
+    del_headers = {
+        "Authorization": requests.auth._basic_auth_str(username, api_token),
+    }
+    del_response = requests.delete(delete_url, headers=del_headers)
+    if del_response.status_code in (200, 204):
+        print(f"Deleted attachment (id: {attachment_id})")
+        return True
+    else:
+        print(
+            f"Failed to delete attachment (id: {attachment_id}): {del_response.status_code} - {del_response.text}"
+        )
+        return False
+
+
+def upload_images_to_confluence(
+    base_url, images, page_id, username, api_token, current_files=None
+):
+    """Upload images to Confluence, skipping unchanged files (by checksum).
+    If an attachment is updated, remove the old one after successful upload.
+    """
     filename_to_fileid = {}
+    current_files = current_files or {}
+
+    # Build a map: filename -> attachment object
+    attachments_by_name = (
+        {att["title"]: att for att in current_files.values()}
+        if isinstance(current_files, dict)
+        and any(isinstance(v, dict) for v in current_files.values())
+        else {}
+    )
+
     for image in images:
         if not os.path.exists(image):
             raise FileNotFoundError(f"Image not found: {image}")
 
-        with open(image, "rb") as img_file:
-            img_data = img_file.read()
-
         filename = os.path.basename(image)
-        url = urljoin(
-            base_url, f"/wiki/rest/api/content/{page_id}/child/attachment?status=draft"
-        )
+        needs_upload = True
+        old_attachment_id = None
 
-        mime_type, _ = mimetypes.guess_type(filename)
-        if not mime_type:
-            mime_type = "application/octet-stream"
+        # If file exists, compare checksum
+        if filename in current_files:
+            # If current_files is a dict of {filename: fileId}, get attachment info from API
+            if not attachments_by_name:
+                attachments = get_page_attachments(
+                    base_url, page_id, username, api_token
+                )
+                attachments_by_name = {att["title"]: att for att in attachments}
+            attachment = attachments_by_name.get(filename)
+            if attachment:
+                remote_url = _get_attachment_download_url(base_url, attachment)
+                if remote_url:
+                    local_sha = _calculate_file_sha256(image)
+                    remote_sha = _calculate_remote_sha256(
+                        remote_url, username, api_token
+                    )
+                    if local_sha == remote_sha:
+                        filename_to_fileid[filename] = attachment["extensions"][
+                            "fileId"
+                        ]
+                        print(f"Skipping unchanged image: {filename}")
+                        needs_upload = False
+                    else:
+                        old_attachment_id = attachment["id"]
 
-        files = {"file": (filename, img_data, mime_type)}
+        if needs_upload:
+            with open(image, "rb") as img_file:
+                img_data = img_file.read()
 
-        headers = {
-            "Authorization": requests.auth._basic_auth_str(username, api_token),
-            "X-Atlassian-Token": "no-check",
-        }
-
-        response = requests.post(url, headers=headers, files=files)
-
-        if response.status_code in (200, 201):
-            file_id = response.json()["results"][0]["extensions"]["fileId"]
-            print(f"Uploaded image: {filename} with ID: {file_id}")
-            filename_to_fileid[filename] = file_id
-        else:
-            print(
-                f"Failed to upload image {filename}: {response.status_code} - {response.text}"
+            url = urljoin(
+                base_url,
+                f"/wiki/rest/api/content/{page_id}/child/attachment?status=draft",
             )
+
+            mime_type, _ = mimetypes.guess_type(filename)
+            if not mime_type:
+                mime_type = "application/octet-stream"
+
+            files = {"file": (filename, img_data, mime_type)}
+
+            headers = {
+                "Authorization": requests.auth._basic_auth_str(username, api_token),
+                "X-Atlassian-Token": "no-check",
+            }
+
+            response = requests.post(url, headers=headers, files=files)
+
+            if response.status_code in (200, 201):
+                file_id = response.json()["results"][0]["extensions"]["fileId"]
+                print(f"Uploaded image: {filename} with ID: {file_id}")
+                filename_to_fileid[filename] = file_id
+
+                # Remove old attachment if it existed and was replaced
+                if old_attachment_id:
+                    delete_attachment(base_url, old_attachment_id, username, api_token)
+            else:
+                print(
+                    f"Failed to upload image {filename}: {response.status_code} - {response.text}"
+                )
     return filename_to_fileid

--- a/helper_scripts/upload_to_confluence.py
+++ b/helper_scripts/upload_to_confluence.py
@@ -4,44 +4,73 @@ from asciidoc_resources import extract_images_and_includes
 from confluence_api import (
     create_empty_page,
     upload_images_to_confluence,
-    update_page_content
+    update_page_content,
+    get_page_info,
 )
 from adf_media import update_adf_media_ids
 
+
 @click.command()
-@click.option('--base-url', required=True, help="Base URL of your Confluence instance (e.g. https://your-domain.atlassian.net)")
-@click.option('--asciidoc', required=True, help="Path to the main Asciidoctor file.")
-@click.option('--adf', required=True, help="Path to the converted ADF JSON file.")
-@click.option('--space-id', required=True, type=int, help="Confluence space ID.")
-@click.option('--title', required=True, help="Title of the Confluence page.")
-@click.option('--username', required=True, help="Confluence username (email).")
-@click.option('--api-token', required=True, help="Confluence API token.")
-def main(base_url, asciidoc, adf, space_id, title, username, api_token):
+@click.option(
+    "--base-url",
+    required=True,
+    help="Base URL of your Confluence instance (e.g. https://your-domain.atlassian.net)",
+)
+@click.option("--asciidoc", required=True, help="Path to the main Asciidoctor file.")
+@click.option("--adf", required=True, help="Path to the converted ADF JSON file.")
+@click.option("--space-id", required=True, type=int, help="Confluence space ID.")
+@click.option("--title", required=True, help="Title of the Confluence page.")
+@click.option("--username", required=True, help="Confluence username (email).")
+@click.option("--api-token", required=True, help="Confluence API token.")
+@click.option(
+    "--page-id",
+    required=False,
+    type=str,
+    help="ID of the existing Confluence page to update. If not provided, a new page will be created.",
+)
+def main(base_url, asciidoc, adf, space_id, title, username, api_token, page_id):
     images = []
     extract_images_and_includes(asciidoc, images)
 
-    page_id = create_empty_page(base_url, space_id, title, username, api_token)
-    print("Created empty page with ID:", page_id)
-    
-    if page_id:
-        print("Uploading images to Confluence...")
-        filename_to_fileid = upload_images_to_confluence(base_url, images, page_id, username, api_token)
-        with open(adf, 'r') as f:
-            adf_json = json.load(f)
-
-        patched_adf = update_adf_media_ids(adf_json, filename_to_fileid)
-        temp_adf_path = adf + ".patched"
-        with open(temp_adf_path, 'w') as f:
-            json.dump(patched_adf, f)
-        print("Patched ADF path:", temp_adf_path)
-
-        print("Updating page content...")
-        update_page_content(base_url, page_id, patched_adf, username, api_token)
+    # If page_id is not provided, create a new page
+    if not page_id:
+        page_id = create_empty_page(base_url, space_id, title, username, api_token)
+        print("Created empty page with ID:", page_id)
     else:
-        print("Failed to create page. Exiting.")
+        print("Updating existing page with ID:", page_id)
+
+    if not page_id:
+        print("Failed to create or find page. Exiting.")
         return
-    
+
+    # Get current attachments for the page
+    from confluence_api import get_page_attachments
+
+    current_attachments = get_page_attachments(base_url, page_id, username, api_token)
+    current_files = {
+        att["title"]: att["extensions"]["fileId"] for att in current_attachments
+    }
+
+    # Upload new/changed images
+    print("Uploading images to Confluence...")
+    filename_to_fileid = upload_images_to_confluence(
+        base_url, images, page_id, username, api_token, current_files
+    )
+
+    with open(adf, "r") as f:
+        adf_json = json.load(f)
+
+    patched_adf = update_adf_media_ids(adf_json, filename_to_fileid)
+    temp_adf_path = adf + ".patched"
+    with open(temp_adf_path, "w") as f:
+        json.dump(patched_adf, f)
+    print("Patched ADF path:", temp_adf_path)
+
+    print("Updating page content...")
+    update_page_content(base_url, page_id, patched_adf, username, api_token)
+
     print("Upload completed successfully.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Added functionality to specify the `page_id` in the upload script to overwrite/update an existing page