### PR TITLE
fixed a bug with uploading documents to newly created confluence pages

### DIFF
--- a/helper_scripts/confluence_client.py
+++ b/helper_scripts/confluence_client.py
@@ -111,8 +111,8 @@ class ConfluenceClient:
         page_info = self.get_page_info(page_id)
         if not page_info:
             return False
-
-        current_version = page_info["version"]["number"]
+        
+        new_version = page_info["version"]["number"] + 1 if page_info["status"] != "draft" else page_info["version"]["number"]
         title = page_info["title"]
         status = page_info["status"]
 
@@ -121,7 +121,7 @@ class ConfluenceClient:
             "id": page_id,
             "status": status,
             "title": title,
-            "version": {"number": current_version + 1},  # increment version!
+            "version": {"number": new_version},
             "body": {"value": inner_json_str, "representation": "atlas_doc_format"},
         }
 


### PR DESCRIPTION
When uploading documents to confluence without providing an existing page id (i.e. creating a new page), it would fail with the following error:

```
Response: {"errors":[{"status":400,"code":"BAD_REQUEST","title":"DRAFT pages do not support multiple versions. Expected version: [1]. Provided version: [2]","detail":null}]}...
```

This PR fixes a bug in determining the version to use when uploading to a newly created page