### PR TITLE
Handle asciidoctor sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The **Jira issues table macro** allows you to embed query results from Jira dire
 
 **Usage:**
 ```adoc
-jiraIssuesTable::["project = DEMO", fields="key,summary,description,status"]
+jiraIssuesTable::"project = DEMO"[fields="key,summary,description,status"]
 ```
 
 **Parameters:**
@@ -98,7 +98,7 @@ jiraIssuesTable::["project = DEMO", fields="key,summary,description,status"]
 
 **Example with more options:**
 ```adoc
-jiraIssuesTable::["project = PRQ AND status = Review", fields="key,summary,description,customfield_10984,status"]
+jiraIssuesTable::"project = PRQ AND status = Review"[fields="key,summary,description,customfield_10984,status"]
 ```
 
 The macro will:

--- a/src/adf_converter.rb
+++ b/src/adf_converter.rb
@@ -47,6 +47,9 @@ class AdfConverter < Asciidoctor::Converter::Base
     when 'toc' then convert_toc(node)
     when 'literal' then convert_literal(node)
     when 'pass' then convert_pass(node)
+    when 'sidebar' then convert_sidebar(node)
+    when 'floating_title' then convert_floating_title(node)
+    when 'thematic_break' then convert_thematic_break(node)
     else
       super
     end
@@ -271,6 +274,24 @@ class AdfConverter < Asciidoctor::Converter::Base
 
   def convert_embedded(node)
     ""
+  end
+
+  # Sidebar blocks are currently ignored (no-op)
+  def convert_sidebar(node)
+    # intentionally left blank
+    nil
+  end
+
+  # Floating titles are currently ignored (no-op)
+  def convert_floating_title(node)
+    # intentionally left blank
+    nil
+  end
+
+  # Thematic breaks are currently ignored (no-op)
+  def convert_thematic_break(node)
+    # intentionally left blank
+    nil
   end
 
   def convert_toc(node)


### PR DESCRIPTION
Hey @adrpar, 
I've excluded further elements from conversion (otherwise docs with sidebar won't work).

I've also fixed the examples for the jiraIssuesTable macro – at least I believe I did, because it's still not working. Even simple examples fail without an error, with the result that the Confluence page contains the makro command instead of an expanded table. 